### PR TITLE
Initial age fix

### DIFF
--- a/Source/moja.modules.cbm/include/moja/modules/cbm/cbmbuildlandunitmodule.h
+++ b/Source/moja.modules.cbm/include/moja/modules/cbm/cbmbuildlandunitmodule.h
@@ -28,6 +28,7 @@ namespace cbm {
         const flint::IVariable* _initialHistoricLandClass;
         const flint::IVariable* _initialCurrentLandClass;
 
+        flint::IVariable* _age;
         flint::IVariable* _buildWorked;
         flint::IVariable* _cset;
         flint::IVariable* _historicLandClass;

--- a/Source/moja.modules.cbm/src/cbmbuildlandunitmodule.cpp
+++ b/Source/moja.modules.cbm/src/cbmbuildlandunitmodule.cpp
@@ -24,6 +24,8 @@ namespace cbm {
 	}
 
     void CBMBuildLandUnitModule::doLocalDomainInit() {
+        _initialAge = _landUnitData->getVariable("initial_age");
+        _age = _landUnitData->getVariable("age");
         _buildWorked = _landUnitData->getVariable("landUnitBuildSuccess");
         _initialCSet = _landUnitData->getVariable("initial_classifier_set");
         _cset = _landUnitData->getVariable("classifier_set");
@@ -65,7 +67,14 @@ namespace cbm {
             _currentLandClass->set_value(currentLandClass);
         }
 
-        _isForest->set_value(true);
+        // -1 = non-forest; forested pixels must have an initial age value.
+        if (_initialAge->value().isEmpty()) {
+            _age->set_value(-1);
+            _isForest->set_value(false);
+        } else {
+            _isForest->set_value(true);
+        }
+
         _buildWorked->set_value(true);
     }
 

--- a/Source/moja.modules.cbm/src/cbmdisturbanceeventmodule.cpp
+++ b/Source/moja.modules.cbm/src/cbmdisturbanceeventmodule.cpp
@@ -8,7 +8,6 @@
 #include <moja/notificationcenter.h>
 
 #include <boost/format.hpp>
-#include <boost/math/special_functions/relative_difference.hpp>
 
 namespace moja {
 namespace modules {
@@ -74,7 +73,7 @@ namespace cbm {
 			+ _softwoodFoliage->value() + _softwoodMerch->value()
 			+ _softwoodOther->value();
 
-		if (totalBiomass < 0 || boost::math::relative_difference(totalBiomass, 0.0) < 0.001) {
+		if (totalBiomass < 0.001) {
 			_age->set_value(0);
 		}
 	}


### PR DESCRIPTION
Fixed issue where pixels could be partially simulated because they pass all the build land unit checks, i.e. they have a valid classifier set but no initial age. This was causing non-forest/nodata pixels to appear in the output using the previous age variable value, affecting area totals.