### PR TITLE
CI: Implement Docker-based CI/CD workflow for GCBM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: Moja Canada CI/CD
+
+on:
+  push:
+    branches: [ develop ]
+
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [ develop ]
+
+env:
+  REGISTRY: ghcr.io
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-moja-canada:
+    name: Publish Moja Canada
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/moja-global/moja.canada
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #
 # ==================================================================================================================
 
-FROM moja/flint:ubuntu-18.04
+FROM ghcr.io/moja-global/flint.core:master AS base
 
 ARG NUM_CPU=1
 ARG BUILD_TYPE=DEBUG
@@ -41,7 +41,7 @@ RUN apt-get update -y && apt-get install -y \
 
 # Rebuild POCO - ensure ODBC is included.
 WORKDIR /tmp
-RUN wget https://pocoproject.org/releases/poco-${POCO_VERSION}/poco-${POCO_VERSION}-all.tar.gz \
+RUN wget --progress=dot:giga https://pocoproject.org/releases/poco-${POCO_VERSION}/poco-${POCO_VERSION}-all.tar.gz \
     && tar -xzf poco-${POCO_VERSION}-all.tar.gz && mkdir poco-${POCO_VERSION}-all/cmake-build && cd poco-${POCO_VERSION}-all/cmake-build \
     && cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$ROOTDIR \
             -DPOCO_UNBUNDLED=ON \
@@ -86,7 +86,15 @@ RUN git clone --recursive https://github.com/jtv/libpqxx.git \
     && make clean
 
 # moja.canada
-RUN cd $ROOTDIR/src && git clone -b develop https://github.com/moja-global/moja.canada
+# RUN cd $ROOTDIR/src && git clone -b develop https://github.com/moja-global/moja.canada
+
+FROM base
+
+WORKDIR $ROOTDIR/src
+
+RUN mkdir -p moja.canada
+
+COPY . ./moja.canada
 
 WORKDIR $ROOTDIR/src/moja.canada/Source/build
 RUN cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \


### PR DESCRIPTION
## Description

This PR:

- Adds a CI/CD workflow to build and push the Docker image on every push and test the build on every PR
- Fixes the Dockerfile by using moja global's GHCR image 
- Refactors the Dockerfile to copy the current directory rather than cloning the `moja.canada` repository

The workflow has been tested and the fixes have been validated on my personal fork and the [moja.canada image](https://github.com/HarshCasper/moja.canada/pkgs/container/moja.canada) has been retrieved. 