### PR TITLE
chore: add clang format and git hooks for moja.canada

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -1,0 +1,190 @@
+---
+BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -209,3 +209,24 @@ message(STATUS "Installation target path: ${CMAKE_INSTALL_PREFIX}")
 
 message(STATUS "C_FLAGS:  =${CMAKE_C_FLAGS}")
 message(STATUS "CXX_FLAGS:=${CMAKE_CXX_FLAGS}")
+
+# clang-format and tidy
+
+find_package(ClangFormat)
+
+if(CLANG_FORMAT_FOUND)
+        message("clang-format executable: ${CLANG_FORMAT_EXECUTABLE}")
+        message("clang-format version: ${CLANG_FORMAT_VERSION}")
+else()
+        message(WARNING "clang-format executable not found")
+endif()
+
+include(cmake/ClangDevTools.cmake)
+
+# Install githooks directory
+
+message("Installing git hooks at ${CMAKE_CURRENT_SOURCE_DIR} with `git config --local core.hooksPath githooks`")
+execute_process(
+    COMMAND git config --local core.hooksPath githooks
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/Source/cmake/ClangDevTools.cmake
+++ b/Source/cmake/ClangDevTools.cmake
@@ -1,0 +1,24 @@
+# See FindClangFormat.cmake
+# Variables of interest on this file: ${CLANG_FORMAT_VERSION} and ${CLANG_FORMAT_EXECUTABLE}
+
+# Get only C/C++ files for now
+file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.hpp *.h *.c *.cc *.hh *.cxx)
+
+# clang-tidy not implemented yet
+#add_custom_target(
+#        clang-tidy
+#        COMMAND /usr/bin/clang-tidy
+#        ${ALL_SOURCE_FILES}
+#        -config=''
+#        --
+#        -std=c++11
+#        ${INCLUDE_DIRECTORIES}
+#)
+
+add_custom_target(
+        clang-format
+        COMMAND ${CLANG_FORMAT_EXECUTABLE}
+        -style=file
+        -i
+        ${ALL_SOURCE_FILES}
+)

--- a/Source/cmake/FindClangFormat.cmake
+++ b/Source/cmake/FindClangFormat.cmake
@@ -1,0 +1,74 @@
+# The module defines the following variables
+#
+# ``CLANG_FORMAT_EXECUTABLE`` Path to clang-format executable
+# ``CLANG_FORMAT_FOUND`` True if the clang-format executable was found.
+# ``CLANG_FORMAT_VERSION`` The version of clang-format found
+# ``CLANG_FORMAT_VERSION_MAJOR`` The clang-format major version if specified, 0
+# otherwise ``CLANG_FORMAT_VERSION_MINOR`` The clang-format minor version if
+# specified, 0 otherwise ``CLANG_FORMAT_VERSION_PATCH`` The clang-format patch
+# version if specified, 0 otherwise ``CLANG_FORMAT_VERSION_COUNT`` Number of
+# version components reported by clang-format
+#
+# Example usage:
+#
+# .. code-block:: cmake
+#
+# find_package(ClangFormat) if(CLANG_FORMAT_FOUND) message("clang-format
+# executable found: ${CLANG_FORMAT_EXECUTABLE}\n" "version:
+# ${CLANG_FORMAT_VERSION}") endif()
+
+find_program(CLANG_FORMAT_EXECUTABLE
+             NAMES clang-format-11
+                   clang-format
+                   clang-format-10
+                   clang-format-12
+                   clang-format-9
+             DOC "clang-format executable")
+mark_as_advanced(CLANG_FORMAT_EXECUTABLE)
+
+# Extract version from command "clang-format -version"
+if(CLANG_FORMAT_EXECUTABLE)
+  execute_process(COMMAND ${CLANG_FORMAT_EXECUTABLE} -version
+                  OUTPUT_VARIABLE clang_format_version
+                  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(clang_format_version MATCHES "clang-format version .*")
+    # clang_format_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1
+    # (tags/RELEASE_391/rc2)"
+    string(REGEX
+           REPLACE ".*clang-format version ([.0-9]+).*"
+                   "\\1"
+                   CLANG_FORMAT_VERSION
+                   "${clang_format_version}")
+    # CLANG_FORMAT_VERSION sample: "3.9.1"
+
+    # Extract version components
+    string(REPLACE "."
+                   ";"
+                   clang_format_version
+                   "${CLANG_FORMAT_VERSION}")
+    list(LENGTH clang_format_version CLANG_FORMAT_VERSION_COUNT)
+    if(CLANG_FORMAT_VERSION_COUNT GREATER 0)
+      list(GET clang_format_version 0 CLANG_FORMAT_VERSION_MAJOR)
+    else()
+      set(CLANG_FORMAT_VERSION_MAJOR 0)
+    endif()
+    if(CLANG_FORMAT_VERSION_COUNT GREATER 1)
+      list(GET clang_format_version 1 CLANG_FORMAT_VERSION_MINOR)
+    else()
+      set(CLANG_FORMAT_VERSION_MINOR 0)
+    endif()
+    if(CLANG_FORMAT_VERSION_COUNT GREATER 2)
+      list(GET clang_format_version 2 CLANG_FORMAT_VERSION_PATCH)
+    else()
+      set(CLANG_FORMAT_VERSION_PATCH 0)
+    endif()
+  endif()
+  unset(clang_format_version)
+endif()
+
+if(CLANG_FORMAT_EXECUTABLE)
+  set(CLANG_FORMAT_FOUND TRUE)
+else()
+  set(CLANG_FORMAT_FOUND FALSE)
+endif()

--- a/Source/githooks/canonicalize_filename.sh
+++ b/Source/githooks/canonicalize_filename.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+canonicalize_filename () {
+    local target_file="$1"
+    local physical_directory=""
+    local result=""
+
+    # Need to restore the working directory after work.
+    local working_dir="`pwd`"
+
+    cd -- "$(dirname -- "$target_file")"
+    target_file="$(basename -- "$target_file")"
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$target_file" ]
+    do
+        target_file="$(readlink -- "$target_file")"
+        cd -- "$(dirname -- "$target_file")"
+        target_file="$(basename -- "$target_file")"
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    physical_directory="`pwd -P`"
+    result="$physical_directory/$target_file"
+
+    # restore the working directory after work.
+    cd -- "$working_dir"
+
+    echo "$result"
+}

--- a/Source/githooks/pre-commit
+++ b/Source/githooks/pre-commit
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Git pre-commit hook that runs multiple hooks specified in $HOOKS.
+# Make sure this script is executable. Bypass hooks with git commit --no-verify.
+
+###########################################################
+# CONFIGURATION:
+# pre-commit hooks to be executed. They should be in the same .git/hooks/ folder
+# as this script. Hooks should return 0 if successful and nonzero to cancel the
+# commit. They are executed in the order in which they are listed.
+#HOOKS="pre-commit-compile pre-commit-uncrustify"
+HOOKS="pre-commit-clang-format"
+###########################################################
+# There should be no need to change anything below this line.
+
+. "$(dirname -- "$0")/canonicalize_filename.sh"
+
+# exit on error
+set -e
+
+# Absolute path to this script, e.g. /home/user/bin/foo.sh
+SCRIPT="$(canonicalize_filename "$0")"
+
+# Absolute path this script is in, thus /home/user/bin
+SCRIPTPATH="$(dirname -- "$SCRIPT")"
+
+
+for hook in $HOOKS
+do
+    echo "Running hook: $hook"
+    # run hook if it exists
+    # if it returns with nonzero exit with 1 and thus abort the commit
+    if [ -f "$SCRIPTPATH/$hook" ]; then
+        "$SCRIPTPATH/$hook"
+        if [ $? != 0 ]; then
+            exit 1
+        fi
+    else
+        echo "Error: file $hook not found."
+        echo "Aborting commit. Make sure the hook is in $SCRIPTPATH and executable."
+        echo "You can disable it by removing it from the list in $SCRIPT."
+        echo "You can skip all pre-commit hooks with --no-verify (not recommended)."
+        exit 1
+    fi
+done

--- a/Source/githooks/pre-commit-clang-format
+++ b/Source/githooks/pre-commit-clang-format
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+
+# git pre-commit hook that runs a clang-format stylecheck.
+# Features:
+#  - abort commit when commit does not comply with the style guidelines
+#  - create a patch of the proposed style changes
+
+# To get consistent formatting, we recommend contributors to use the same
+# clang-format version as CI.
+RECOMMENDED_CLANG_FORMAT_MAJOR="11"
+
+CLANG_FORMAT=`which clang-format-$RECOMMENDED_CLANG_FORMAT_MAJOR 2>/dev/null`
+if [ -z "${CLANG_FORMAT+x}" ]; then
+  CLANG_FORMAT=`which clang-format 2>/dev/null`
+fi
+
+# Remove any older patches from previous commits. Set to true or false.
+DELETE_OLD_PATCHES=false
+
+# Only parse files with the extensions in FILE_EXTS. Set to true or false.
+# If false every changed file in the commit will be parsed with clang-format.
+# If true only files matching one of the extensions are parsed with clang-format.
+PARSE_EXTS=true
+
+# File types to parse. Only effective when PARSE_EXTS is true.
+FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx"
+
+# Use pygmentize instead of cat to parse diff with highlighting.
+# Install it with `pip install pygments` (Linux) or `easy_install Pygments` (Mac)
+PYGMENTIZE=`which pygmentize 2>/dev/null`
+if [ ! -z "$PYGMENTIZE" ]; then
+  READER="pygmentize -l diff"
+else
+  READER=cat
+fi
+
+# Path to zenity
+ZENITY=`which zenity 2>/dev/null`
+
+# Path to xmessage
+XMSG=`which xmessage 2>/dev/null`
+
+# Path to powershell (Windows only)
+PWSH=`which powershell 2>/dev/null`
+
+##################################################################
+# There should be no need to change anything below this line.
+
+. "$(dirname -- "$0")/canonicalize_filename.sh"
+
+# exit on error
+set -e
+
+# check whether the given file matches any of the set extensions
+matches_extension() {
+    local filename=$(basename "$1")
+    local extension=".${filename##*.}"
+    local ext
+
+    for ext in $FILE_EXTS; do [[ "$ext" == "$extension" ]] && return 0; done
+
+    return 1
+}
+
+# necessary check for initial commit
+if git rev-parse --verify HEAD >/dev/null 2>&1 ; then
+    against=HEAD
+else
+    # https://stackoverflow.com/a/25064285/10527823
+    # 4b825dc642cb6eb9a060e54bf8d69288fbee4904 is magic id which always existed. Note: this is an empty tree.
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+if [ ! -x "$CLANG_FORMAT" ] ; then
+	message="Error: clang-format executable not found. Please install clang-format $RECOMMENDED_CLANG_FORMAT_MAJOR.x.x."
+
+    if [ ! -t 1 ] ; then
+        if [ -x "$ZENITY" ] ; then
+            $ZENITY --error --title="Error" --text="$message"
+            exit 1
+        elif [ -x "$XMSG" ] ; then
+            $XMSG -center -title "Error" "$message"
+            exit 1
+        elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
+            winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
+            $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -center -title "Error" --text "$message"
+            exit 1
+        fi
+    fi
+    printf "$message\n"
+    printf "Set the correct path in $(canonicalize_filename "$0").\n"
+    exit 1
+fi
+
+# create a random filename to store our generated patch
+prefix="pre-commit-clang-format"
+suffix="$(date +%s)"
+patch="/tmp/$prefix-$suffix.patch"
+
+# clean up any older clang-format patches
+$DELETE_OLD_PATCHES && rm -f /tmp/$prefix*.patch
+
+# create one patch containing all changes to the files
+git diff-index --cached --diff-filter=ACMR --name-only $against -- | while read file;
+do
+    # Only files from source folder
+    if grep -q "source" <<< $file; then
+        : # Correct
+    else
+        continue;
+    fi
+
+
+    # ignore file if we do check for file extensions and the file
+    # does not match any of the extensions specified in $FILE_EXTS
+    if $PARSE_EXTS && ! matches_extension "$file"; then
+        continue;
+    fi
+
+    # clang-format our sourcefile, create a patch with diff and append it to our $patch
+    # The sed call is necessary to transform the patch from
+    #    --- $file timestamp
+    #    +++ - timestamp
+    # to both lines working on the same file and having a/ and b/ prefix.
+    # Else it can not be applied with 'git apply'.
+    "$CLANG_FORMAT" -style=file "$file" | \
+        diff -u "$file" - | \
+        sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
+done
+
+# if no patch has been generated all is ok, clean up the file stub and exit
+if [ ! -s "$patch" ] ; then
+    printf "Files in this commit comply with the clang-format rules.\n"
+    rm -f "$patch"
+    exit 0
+fi
+
+# a patch has been created, notify the user and exit
+printf "\nThe following differences were found between the code to commit "
+printf "and the clang-format rules:\n\n"
+
+if [ -t 1 ] ; then
+    $READER "$patch"
+    printf "\n"
+    # Allows us to read user input below, assigns stdin to keyboard
+    exec < /dev/tty
+    terminal="1"
+else
+    cat "$patch"
+    printf "\n"
+    # Allows non zero zenity/powershell output
+    set +e
+    terminal="0"
+fi
+
+while true; do
+    if [ $terminal = "0" ] ; then
+        if [ -x "$ZENITY" ] ; then
+            ans=$($ZENITY --text-info --filename="$patch" --width=800 --height=600 --title="Do you want to apply that patch?" --ok-label="Apply" --cancel-label="Do not apply" --extra-button="Apply and stage")
+            if [ "$?" = "0" ] ; then
+                yn="Y"
+            else
+                if [ "$ans" = "Apply and stage" ] ; then
+                    yn="S"
+                else
+                    yn="N"
+                fi
+            fi
+        elif [ -x "$XMSG" ] ; then
+            $XMSG -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
+            ans=$?
+            if [ "$ans" = "100" ] ; then
+                yn="Y"
+            elif [ "$ans" = "200" ] ; then
+                yn="S"
+            else
+                yn="N"
+            fi
+        elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
+            winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
+            $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
+            ans=$?
+            if [ "$ans" = "100" ] ; then
+                yn="Y"
+            elif [ "$ans" = "200" ] ; then
+                yn="S"
+            else
+                yn="N"
+            fi
+        else
+            printf "Error: zenity, xmessage, or powershell executable not found.\n"
+            exit 1
+        fi
+    else
+        read -p "Do you want to apply that patch (Y - Apply, N - Do not apply, S - Apply and stage files)? [Y/N/S] " yn
+    fi
+    case $yn in
+        [Yy] ) git apply $patch;
+        printf "The patch was applied. You can now stage the changes and commit again.\n\n";
+        break
+        ;;
+        [Nn] ) printf "\nYou can apply these changes with:\n  git apply $patch\n";
+        printf "(may need to be called from the root directory of your repository)\n";
+        printf "Aborting commit. Apply changes and commit again or skip checking with";
+        printf " --no-verify (not recommended).\n\n";
+        break
+        ;;
+        [Ss] ) git apply $patch;
+        git diff-index --cached --diff-filter=ACMR --name-only $against -- | while read file;
+        do git add $file;
+        done
+        printf "The patch was applied and the changed files staged. You can now commit.\n\n";
+        break
+        ;;
+        * ) echo "Please answer yes or no."
+        ;;
+    esac
+done
+exit 1 # we don't commit in any case

--- a/Source/githooks/winmessage.ps1
+++ b/Source/githooks/winmessage.ps1
@@ -1,0 +1,103 @@
+Param (
+	[string]$file = "",
+	[string]$text = "",
+	[string]$buttons = "OK:0",
+	[string]$default = "",
+	[switch]$nearmouse = $false,
+	[switch]$center = $false,
+	[string]$geometry = "",
+	[int32]$timeout = 0,
+	[string]$title = "Message"
+)
+Add-Type -assembly System.Windows.Forms
+
+$global:Result = 0
+
+$main_form = New-Object System.Windows.Forms.Form
+$main_form.Text = $title
+
+$geometry_data = $geometry.Split("+")
+if ($geometry_data.Length -ge 1) {
+	$size_data = $geometry_data[0].Split("x")
+	if ($size_data.Length -eq 2) {
+		$main_form.Width = $size_data[0]
+		$main_form.Height = $size_data[1]
+	}
+}
+if ($geometry_data.Length -eq 3) {
+	$main_form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+	$main_form.Location = New-Object System.Drawing.Point($geometry_data[1], $geometry_data[2])
+}
+if ($nearmouse) {
+	$main_form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+	$main_form.Location = System.Windows.Forms.Cursor.Position
+}
+if ($center) {
+	$main_form.StartPosition = [System.Windows.Forms.FormStartPosition]::CenterScreen
+}
+
+$main_form.SuspendLayout()
+
+$button_panel = New-Object System.Windows.Forms.FlowLayoutPanel
+$button_panel.SuspendLayout()
+$button_panel.FlowDirection = [System.Windows.Forms.FlowDirection]::RightToLeft
+$button_panel.Dock = [System.Windows.Forms.DockStyle]::Bottom
+$button_panel.Autosize = $true
+
+if ($file -ne "") {
+	$text = [IO.File]::ReadAllText($file).replace("`n", "`r`n")
+}
+
+if ($text -ne "") {
+	$text_box = New-Object System.Windows.Forms.TextBox
+	$text_box.Multiline = $true
+	$text_box.ReadOnly = $true
+	$text_box.Autosize = $true
+	$text_box.Text = $text
+	$text_box.Select(0,0)
+	$text_box.Dock = [System.Windows.Forms.DockStyle]::Fill
+	$main_form.Controls.Add($text_box)
+}
+
+$buttons_array = $buttons.Split(",")
+foreach ($button in $buttons_array) {
+	$button_data = $button.Split(":")
+	$button_ctl = New-Object System.Windows.Forms.Button
+	if ($button_data.Length -eq 2) {
+		$button_ctl.Tag = $button_data[1]
+	} else {
+		$button_ctl.Tag = 100 + $buttons_array.IndexOf($button)
+	}
+	if ($default -eq $button_data[0]) {
+		$main_form.AcceptButton = $button_ctl
+	}
+	$button_ctl.Autosize = $true
+	$button_ctl.Text = $button_data[0]
+	$button_ctl.Add_Click(
+		{
+			Param($sender)
+			$global:Result = $sender.Tag
+			$main_form.Close()
+		}
+	)
+	$button_panel.Controls.Add($button_ctl)
+}
+$main_form.Controls.Add($button_panel)
+
+$button_panel.ResumeLayout($false)
+$main_form.ResumeLayout($false)
+
+if ($timeout -gt 0) {
+	$timer = New-Object System.Windows.Forms.Timer
+	$timer.Add_Tick(
+		{
+			$global:Result = 0
+			$main_form.Close()
+		}
+	)
+	$timer.Interval = $timeout
+	$timer.Start()
+}
+$dlg_res = $main_form.ShowDialog()
+
+[Environment]::Exit($global:Result)


### PR DESCRIPTION
## Description

This PR:

- Adds clang format to `moja.canda` to format C/C++ code as per LLVM standards.
- Sets Git hooks for all major dev environments for pre-commit formatting checks
- Makes apt changes to `CMakeLists.txt` to install and setup clang-format and pre-commit on install.